### PR TITLE
Allow specifying dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
         image-tag: head # Provide Docker image tag
 ```
 
-### Build and publish Docker Image with a `latest` tag for the `master` branch
+### Build and publish Docker Image with a `latest` tag for the `master` branch with different dockerfile
 
 ```yaml
   build-and-publish-latest:
@@ -35,6 +35,7 @@
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
         image-name: my-cool-service # Provide only Docker image name, tag will be automatically set to latest
+        dockerfile: Dockerfile_server
 ```
 
 ### Build and publish Docker Image with a tag equal to a git tag

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
   dockerfile:
     description: 'Dockerfile name'
     default: "Dockerfile"
+    required: false
   build-context:
     description: 'Path to build context'
     default: "."

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Build and publish Docker Image to GitHub Registry'
+name: 'Build and publish Docker Image to GitHub Registry with custom Dockerfile'
 description: 'GitHub Action to publish Docker Images to GitHub Registry'
 inputs:
   github-token:
@@ -15,6 +15,10 @@ inputs:
     description: 'Extract git-tag from repository'
     default: "false"
     required: false
+  dockerfile:
+    description: 'Dockerfile name'
+    default: "Dockerfile"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -23,6 +27,7 @@ runs:
     - ${{ inputs.image-name }}
     - ${{ inputs.image-tag }}
     - ${{ inputs.extract-git-tag }}
+    - ${{ inputs.dockerfile }}
 branding:
   icon: 'box'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Build and publish Docker Image to GitHub Registry with custom Dockerfile'
-description: 'GitHub Action to publish Docker Images to GitHub Registry'
+name: 'Build and publish Docker Image to GitHub Registry'
+description: 'GitHub Action to publish Docker Images to GitHub Registry. It's possible to specify custom Dockerfile and\or build context, if it's required.'
 inputs:
   github-token:
     description: 'GitHub token to push Docker image to GitHub Packages'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,5 +14,5 @@ fi
 DOCKER_IMAGE_FULL_PATH=$(echo docker.pkg.github.com/${GITHUB_REPOSITORY}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} | tr '[:upper:]' '[:lower:]')
 
 docker login -u publisher -p ${DOCKER_TOKEN} docker.pkg.github.com
-docker build -t $DOCKER_IMAGE_FULL_PATH $BUILD_CONTEXT -f $DOCKERFILE
+docker build -t $DOCKER_IMAGE_FULL_PATH -f $DOCKERFILE $BUILD_CONTEXT
 docker push $DOCKER_IMAGE_FULL_PATH

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ DOCKER_TOKEN=$1
 DOCKER_IMAGE_NAME=$2
 DOCKER_IMAGE_TAG=$3
 EXTRACT_TAG_FROM_GIT_REF=$4
+DOCKERFILE=$5
 
 if [ $EXTRACT_TAG_FROM_GIT_REF == "true" ]; then
   DOCKER_IMAGE_TAG=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
@@ -12,5 +13,5 @@ fi
 DOCKER_IMAGE_FULL_PATH=$(echo docker.pkg.github.com/${GITHUB_REPOSITORY}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} | tr '[:upper:]' '[:lower:]')
 
 docker login -u publisher -p ${DOCKER_TOKEN} docker.pkg.github.com
-docker build -t $DOCKER_IMAGE_FULL_PATH .
+docker build -t $DOCKER_IMAGE_FULL_PATH . -f $DOCKERFILE
 docker push $DOCKER_IMAGE_FULL_PATH


### PR DESCRIPTION
This would allow users to specify a different Dockerfile than the default. The default is of course still `Dockerfile`. Feel free to change the name of the action back, I realise we might want it to keep the same name.

I have tested this as working on one of my own repos.