### PR TITLE
Duplication of RepoName & ImageName

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ if [ $EXTRACT_TAG_FROM_GIT_REF == "true" ]; then
   DOCKER_IMAGE_TAG=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
 fi
 
-DOCKER_IMAGE_NAME=$(echo ghcr.io/${GITHUB_REPOSITORY}/${DOCKER_IMAGE_NAME} | tr '[:upper:]' '[:lower:]')
+DOCKER_IMAGE_NAME=$(echo ghcr.io/${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]')
 DOCKER_IMAGE_NAME_WITH_TAG=$(echo ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} | tr '[:upper:]' '[:lower:]')
 
 docker login -u publisher -p ${DOCKER_TOKEN} ghcr.io


### PR DESCRIPTION
For a repo with url ``github.com/TestUser/TestProject`` and ImageName ``TestProject`` the packages are pushed to:
- Push URL: ``github.com/TestUser/TestProject/TestProject``
- Package Address: ``TestProject/TestProject:latest``

This pull request removes the last part and makes it possible to have:
- Push URL: ``github.com/TestUser/TestProject``
- Package Address: ``TestProject:latest``

Overall, it's more clean.
